### PR TITLE
Fix: Upgrade the UUID version and unify the usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2498,6 +2498,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
       "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
@@ -17633,6 +17638,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "require-directory": {
@@ -18644,6 +18656,14 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -21243,9 +21263,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -22974,6 +22994,12 @@
           "version": "3.2.4",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "three": "0.124.0",
     "universal-logger": "1.0.1",
     "universal-logger-browser": "1.0.2",
-    "uuid": "3.3.3",
+    "uuid": "8.3.2",
     "watch": "1.0.2",
     "webappengine": "1.2.0",
     "winston": "3.0.1",

--- a/src/app/flux/editor/actions-process.js
+++ b/src/app/flux/editor/actions-process.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import _ from 'lodash';
 import { baseActions } from './actions-base';
 import { controller } from '../../lib/controller';
@@ -50,7 +50,10 @@ export const processActions = {
             }
         });
         if (visibleToolPathsLength > 0) {
-            progressStatesManager.startProgress(PROCESS_STAGE.CNC_LASER_GENERATE_TOOLPATH_AND_PREVIEW, [visibleToolPathsLength, visibleToolPathsLength, visibleToolPathsLength]);
+            progressStatesManager.startProgress(
+                PROCESS_STAGE.CNC_LASER_GENERATE_TOOLPATH_AND_PREVIEW,
+                [visibleToolPathsLength, visibleToolPathsLength, visibleToolPathsLength]
+            );
         }
         toolPathGroup.toolPaths.forEach((toolPath) => {
             toolPath.setWarningStatus();
@@ -329,16 +332,14 @@ export const processActions = {
         toolPaths[0].thumbnail = toolPathGroup.thumbnail;
 
         dispatch(baseActions.updateState(
-            headType, {
-                isGcodeGenerating: true
-            }
+            headType, { isGcodeGenerating: true }
         ));
         dispatch(baseActions.updateState(headType, {
             stage: STEP_STAGE.CNC_LASER_GENERATING_GCODE,
             progress: progressStatesManager.updateProgress(STEP_STAGE.CNC_LASER_GENERATING_GCODE, 0.1)
         }));
         controller.commitGcodeTask({
-            taskId: uuid.v4(),
+            taskId: uuid(),
             headType: headType,
             data: toolPaths
         });
@@ -415,7 +416,7 @@ export const processActions = {
         }
 
         controller.commitViewPathTask({
-            taskId: uuid.v4(),
+            taskId: uuid(),
             headType: headType,
             data: viewPathInfos
         });

--- a/src/app/flux/editor/index.js
+++ b/src/app/flux/editor/index.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import path from 'path';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import _, { includes } from 'lodash';
 
 import ToolpathRendererWorker from '../../workers/ToolpathRenderer.worker';
@@ -286,7 +286,7 @@ export const actions = {
                 }));
             });
 
-            controller.on('taskProgress:cutModel', () => {});
+            controller.on('taskProgress:cutModel', () => { });
 
             // task completed
             controller.on('taskCompleted:processImage', (taskResult) => {
@@ -893,7 +893,7 @@ export const actions = {
         dispatch(actions.resetProcessState(headType));
 
         controller.commitProcessImage({
-            taskId: uuid.v4(),
+            taskId: uuid(),
             headType: headType,
             data: options
         });
@@ -2035,7 +2035,7 @@ export const actions = {
             }
         }));
         controller.commitCutModelTask({
-            taskId: uuid.v4(),
+            taskId: uuid(),
             headType: headType,
             data: options
         });
@@ -2105,7 +2105,7 @@ export const actions = {
                             throw new Error('geometry invalid');
                         }
                     },
-                    () => {}, // onprogress
+                    () => { }, // onprogress
                     (err) => {
                         onError && onError(err);
                         dispatch(actions.updateState(headType, {

--- a/src/app/flux/workspace/index.js
+++ b/src/app/flux/workspace/index.js
@@ -1,6 +1,6 @@
 // Reducer for Workspace
 import * as THREE from 'three';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import api from '../../api';
 import log from '../../lib/log';
 import { generateRandomPathName } from '../../../shared/lib/random-utils';
@@ -69,7 +69,7 @@ export const actions = {
 
                     const object3D = gcodeBufferGeometryToObj3d('WORKSPACE', bufferGeometry, renderMethod);
                     // object3D.material.uniforms.u_visible_index_count.value = 20000;
-                    object3D.name = gcodeFile ? `${gcodeFile.name}-${uuid.v4()}` : `${gcodeFiles[gcodeFileIndex].name}-${uuid.v4()}`;
+                    object3D.name = gcodeFile ? `${gcodeFile.name}-${uuid()}` : `${gcodeFiles[gcodeFileIndex].name}-${uuid()}`;
 
                     if (isPreview) {
                         previewModelGroup.add(object3D);

--- a/src/app/models/BaseModel.ts
+++ b/src/app/models/BaseModel.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import type ModelGroup from './ModelGroup';
 
 export interface ModelTransformation {
@@ -51,7 +51,7 @@ abstract class BaseModel {
         // eslint-disable-next-line no-return-assign
         Object.keys(modelInfo).map(key => this[key] = modelInfo[key]);
 
-        this.modelID = this.modelID || `id${uuid.v4()}`;
+        this.modelID = this.modelID || `id${uuid()}`;
         this.modelName = this.modelName ?? 'unnamed';
         this.transformation = { ...DEFAULT_TRANSFORMATION, ...this.transformation };
     }

--- a/src/app/models/BaseModel.ts
+++ b/src/app/models/BaseModel.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
-import { v4 } from 'uuid';
+import uuid from 'uuid';
 import type ModelGroup from './ModelGroup';
-// Having to import v4 from @types/uuid in ts file
 
 export interface ModelTransformation {
     positionX: number,
@@ -52,7 +51,7 @@ abstract class BaseModel {
         // eslint-disable-next-line no-return-assign
         Object.keys(modelInfo).map(key => this[key] = modelInfo[key]);
 
-        this.modelID = this.modelID || `id${v4()}`;
+        this.modelID = this.modelID || `id${uuid.v4()}`;
         this.modelName = this.modelName ?? 'unnamed';
         this.transformation = { ...DEFAULT_TRANSFORMATION, ...this.transformation };
     }

--- a/src/app/models/ModelGroup.js
+++ b/src/app/models/ModelGroup.js
@@ -1,7 +1,7 @@
 import { Vector3, Group, Matrix4, BufferGeometry, MeshPhongMaterial, Mesh, DoubleSide, Float32BufferAttribute, MeshBasicMaterial } from 'three';
 import EventEmitter from 'events';
 // import { EPSILON } from '../../constants';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import _ from 'lodash';
 import i18n from '../lib/i18n';
 
@@ -915,10 +915,10 @@ class ModelGroup extends EventEmitter {
                 newModel.meshObject.updateMatrix();
                 newModel.computeBoundingBox();
 
-                newModel.modelID = modelID || uuid.v4();
+                newModel.modelID = modelID || uuid();
             } else {
                 newModel.meshObject.addEventListener('update', this.onModelUpdate);
-                newModel.modelID = modelID || uuid.v4();
+                newModel.modelID = modelID || uuid();
                 newModel.computeBoundingBox();
                 newModel.updateTransformation({
                     positionX: 0,
@@ -971,7 +971,7 @@ class ModelGroup extends EventEmitter {
                 newModel.meshObject.updateMatrix();
                 newModel.computeBoundingBox();
 
-                newModel.modelID = uuid.v4();
+                newModel.modelID = uuid();
 
                 this.models.push(newModel);
                 this.object.add(newModel.meshObject);

--- a/src/app/models/SvgModel.js
+++ b/src/app/models/SvgModel.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import * as THREE from 'three';
 import Canvg from 'canvg';
 import { coordGmSvgToModel } from '../ui/SVGEditor/element-utils';
@@ -1138,7 +1138,7 @@ class SvgModel extends BaseModel {
     clone(modelGroup) {
         const clone = new SvgModel({ ...this }, modelGroup);
         clone.originModelID = this.modelID;
-        clone.modelID = uuid.v4();
+        clone.modelID = uuid();
         clone.generateModelObject3D();
         clone.generateProcessObject3D();
         this.meshObject.updateMatrixWorld();

--- a/src/app/models/ThreeBaseModel.ts
+++ b/src/app/models/ThreeBaseModel.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import type ModelGroup from './ModelGroup';
 import type ThreeGroup from './ThreeGroup';
 
@@ -81,7 +81,7 @@ export default class BaseModel {
         // eslint-disable-next-line no-return-assign
         Object.keys(modelInfo).map(key => this[key] = modelInfo[key]);
 
-        this.modelID = this.modelID || `id${uuid.v4()}`;
+        this.modelID = this.modelID || `id${uuid()}`;
         this.modelName = this.modelName ?? 'unnamed';
         this.transformation = { ...DEFAULT_TRANSFORMATION, ...this.transformation };
         this.type = modelInfo.type || 'baseModel';

--- a/src/app/models/ThreeBaseModel.ts
+++ b/src/app/models/ThreeBaseModel.ts
@@ -1,9 +1,7 @@
 import * as THREE from 'three';
-// import uuid from 'uuid';
+import uuid from 'uuid';
 import type ModelGroup from './ModelGroup';
 import type ThreeGroup from './ThreeGroup';
-
-const uuid = require('uuid');
 
 export type ModelTransformation = {
     positionX?: number;
@@ -83,7 +81,7 @@ export default class BaseModel {
         // eslint-disable-next-line no-return-assign
         Object.keys(modelInfo).map(key => this[key] = modelInfo[key]);
 
-        this.modelID = this.modelID || `id${uuid()}`;
+        this.modelID = this.modelID || `id${uuid.v4()}`;
         this.modelName = this.modelName ?? 'unnamed';
         this.transformation = { ...DEFAULT_TRANSFORMATION, ...this.transformation };
         this.type = modelInfo.type || 'baseModel';

--- a/src/app/models/ThreeModel.js
+++ b/src/app/models/ThreeModel.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import * as THREE from 'three';
 import {
     LOAD_MODEL_FROM_INNER
@@ -267,7 +267,7 @@ class ThreeModel extends BaseModel {
         };
         const clone = new ThreeModel(modelInfo, modelGroup);
         clone.originModelID = this.modelID;
-        clone.modelID = uuid.v4();
+        clone.modelID = uuid();
         this.meshObject.updateMatrixWorld();
 
         clone.setMatrix(this.meshObject.matrixWorld);

--- a/src/app/toolpaths/ToolPath.js
+++ b/src/app/toolpaths/ToolPath.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { includes } from 'lodash';
 import * as THREE from 'three';
 import { controller } from '../lib/controller';
@@ -44,7 +44,7 @@ class ToolPath {
         const { id, name, baseName, headType, type, useLegacyEngine = false, modelMode,
             visibleModelIDs, gcodeConfig, toolParams = {}, materials = {}, modelGroup } = options;
 
-        this.id = id || uuid.v4();
+        this.id = id || uuid();
         this.name = name;
         this.baseName = baseName;
         this.headType = headType;

--- a/src/app/ui/SVGEditor/PrintableArea.js
+++ b/src/app/ui/SVGEditor/PrintableArea.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { createSVGElement } from './element-utils';
 import {
     EPSILON
@@ -7,7 +7,7 @@ import { isEqual } from '../../../shared/lib/utils';
 
 class PrintableArea {
     constructor(svgFactory) {
-        this.id = uuid.v4();
+        this.id = uuid();
         this.svgFactory = svgFactory;
         this.size = {
             ...svgFactory.size
@@ -116,7 +116,7 @@ class PrintableArea {
                     y1: i,
                     x2: xMax,
                     y2: i,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -135,7 +135,7 @@ class PrintableArea {
                     y1: i,
                     x2: xMax,
                     y2: i,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -154,7 +154,7 @@ class PrintableArea {
                     y1: yMin,
                     x2: i,
                     y2: yMax,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -173,7 +173,7 @@ class PrintableArea {
                     y1: yMin,
                     x2: i,
                     y2: yMax,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -194,7 +194,7 @@ class PrintableArea {
                     y1: i,
                     x2: xMax,
                     y2: i,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -207,7 +207,7 @@ class PrintableArea {
                 attr: {
                     x: x + (coordinateModeName.indexOf('right') !== -1 ? 6 : -6),
                     y: i + 1.2,
-                    id: uuid.v4(),
+                    id: uuid(),
                     'font-size': textSize,
                     'font-family': 'roboto',
                     fill: colorTextFill,
@@ -232,7 +232,7 @@ class PrintableArea {
                     y1: i,
                     x2: xMax,
                     y2: i,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -245,7 +245,7 @@ class PrintableArea {
                 attr: {
                     x: x + (coordinateModeName.indexOf('right') !== -1 ? 6 : -6),
                     y: i + 1.2,
-                    id: uuid.v4(),
+                    id: uuid(),
                     'font-size': textSize,
                     'font-family': 'roboto',
                     fill: colorTextFill,
@@ -270,7 +270,7 @@ class PrintableArea {
                     y1: yMin,
                     x2: i,
                     y2: yMax,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -283,7 +283,7 @@ class PrintableArea {
                 attr: {
                     x: i,
                     y: y + (coordinateModeName.indexOf('top') !== -1 ? -3 : 6),
-                    id: uuid.v4(),
+                    id: uuid(),
                     'font-size': textSize,
                     'font-family': 'roboto',
                     fill: colorTextFill,
@@ -309,7 +309,7 @@ class PrintableArea {
                     y1: yMin,
                     x2: i,
                     y2: yMax,
-                    id: uuid.v4(),
+                    id: uuid(),
                     stroke: color,
                     fill: 'none',
                     'stroke-width': 1 / this.scale,
@@ -322,7 +322,7 @@ class PrintableArea {
                 attr: {
                     x: i,
                     y: y + (coordinateModeName.indexOf('top') !== -1 ? -3 : 6),
-                    id: uuid.v4(),
+                    id: uuid(),
                     'font-size': textSize,
                     'font-family': 'roboto',
                     fill: colorTextFill,
@@ -349,7 +349,7 @@ class PrintableArea {
                 y1: yMin,
                 x2: xMin,
                 y2: yMax,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: borderColor,
                 fill: 'none',
                 'stroke-width': 1 / this.scale,
@@ -364,7 +364,7 @@ class PrintableArea {
                 y1: yMin,
                 x2: xMax,
                 y2: yMax,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: borderColor,
                 fill: 'none',
                 'stroke-width': 1 / this.scale,
@@ -379,7 +379,7 @@ class PrintableArea {
                 y1: yMin,
                 x2: xMax,
                 y2: yMin,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: borderColor,
                 fill: 'none',
                 'stroke-width': 1 / this.scale,
@@ -394,7 +394,7 @@ class PrintableArea {
                 y1: yMax,
                 x2: xMax,
                 y2: yMax,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: borderColor,
                 fill: 'none',
                 'stroke-width': 1 / this.scale,
@@ -416,7 +416,7 @@ class PrintableArea {
                 y1: y1,
                 x2: x2,
                 y2: y2,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: color,
                 fill: 'none',
                 'stroke-dasharray': dashed ? '1, 1' : '',
@@ -433,7 +433,7 @@ class PrintableArea {
             attr: {
                 x: 30,
                 y: 30,
-                id: uuid.v4(),
+                id: uuid(),
                 'font-size': 24,
                 'font-family': 'roboto',
                 fill: '#ff7f00',
@@ -462,7 +462,7 @@ class PrintableArea {
                 y: yMin,
                 width: xMax - xMin,
                 height: yMax - yMin,
-                id: uuid.v4(),
+                id: uuid(),
                 stroke: '#B9BCBF',
                 fill: '#FFFFFF',
                 'stroke-width': 2 / this.scale,

--- a/src/app/ui/SVGEditor/svg-content/SVGContentGroup.js
+++ b/src/app/ui/SVGEditor/svg-content/SVGContentGroup.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { createSVGElement, getBBox, toString } from '../element-utils';
 import { NS } from '../lib/namespaces';
 // import SelectorManager from './SelectorManager';
@@ -69,7 +69,7 @@ class SVGContentGroup {
 
     // for create new elem
     getNewId() {
-        this.svgId = `id${uuid.v4()}`;
+        this.svgId = `id${uuid()}`;
         return this.svgId;
     }
 
@@ -117,7 +117,7 @@ class SVGContentGroup {
     }
 
     findSVGElement(id) {
-        // uuid.v4() may generate id starts with digit, that will cause querySelector fail
+        // uuid() may generate id starts with digit, that will cause querySelector fail
         // https://stackoverflow.com/questions/37270787/uncaught-syntaxerror-failed-to-execute-queryselector-on-document
         return this.svgContent.getElementById(`${id}`);
     }

--- a/src/package.json
+++ b/src/package.json
@@ -72,7 +72,7 @@
     "tar": "6.1.11",
     "three": "0.124.0",
     "universal-logger": "1.0.1",
-    "uuid": "3.3.3",
+    "uuid": "8.3.2",
     "watch": "1.0.2",
     "webappengine": "1.2.0",
     "winston": "3.0.1",

--- a/src/server/services/api/api-commands.js
+++ b/src/server/services/api/api-commands.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import castArray from 'lodash/castArray';
 import isPlainObject from 'lodash/isPlainObject';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import settings from '../../config/settings';
 import logger from '../../lib/logger';
 // import taskRunner from '../services/taskrunner';
@@ -28,7 +28,7 @@ const getSanitizedRecords = () => {
         const record = records[i];
 
         if (!record.id) {
-            record.id = uuid.v4();
+            record.id = uuid();
             shouldUpdate = true;
         }
 
@@ -98,7 +98,7 @@ export const create = (req, res) => {
     try {
         const records = getSanitizedRecords();
         const record = {
-            id: uuid.v4(),
+            id: uuid(),
             mtime: new Date().getTime(),
             enabled: !!enabled,
             title: title,

--- a/src/server/services/api/api-events.js
+++ b/src/server/services/api/api-events.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import castArray from 'lodash/castArray';
 import isPlainObject from 'lodash/isPlainObject';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import settings from '../../config/settings';
 import logger from '../../lib/logger';
 import config from '../configstore';
@@ -27,7 +27,7 @@ const getSanitizedRecords = () => {
         const record = records[i];
 
         if (!record.id) {
-            record.id = uuid.v4();
+            record.id = uuid();
             shouldUpdate = true;
         }
 
@@ -105,7 +105,7 @@ export const create = (req, res) => {
     try {
         const records = getSanitizedRecords();
         const record = {
-            id: uuid.v4(),
+            id: uuid(),
             mtime: new Date().getTime(),
             enabled: !!enabled,
             event: event,

--- a/src/server/services/api/api-file.js
+++ b/src/server/services/api/api-file.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import mv from 'mv';
 import fs from 'fs';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { pathWithRandomSuffix } from '../../lib/random-utils';
 import logger from '../../lib/logger';
 import DataStorage, { rmDir } from '../../DataStorage';
@@ -371,7 +371,7 @@ export const packageEnv = async (req, res) => {
     // const content = fs.readFileSync(targetPath).toString();
     // const config = JSON.parse(content);
 
-    const targetFile = `${uuid.v4().substring(0, 8)}${tails[headType]}`;
+    const targetFile = `${uuid().substring(0, 8)}${tails[headType]}`;
     await zipFolder(envDir, `../../Tmp/${targetFile}`);
     // config.models.forEach((model) => {
     //     const { originalName, uploadName } = model;

--- a/src/server/services/api/api-macros.js
+++ b/src/server/services/api/api-macros.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import castArray from 'lodash/castArray';
 import isPlainObject from 'lodash/isPlainObject';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import settings from '../../config/settings';
 import logger from '../../lib/logger';
 import config from '../configstore';
@@ -27,7 +27,7 @@ const getSanitizedRecords = () => {
         const record = records[i];
 
         if (!record.id) {
-            record.id = uuid.v4();
+            record.id = uuid();
             shouldUpdate = true;
         }
     }
@@ -81,7 +81,7 @@ export const create = (req, res) => {
     try {
         const records = getSanitizedRecords();
         const record = {
-            id: uuid.v4(),
+            id: uuid(),
             mtime: new Date().getTime(),
             name,
             content,

--- a/src/server/services/api/api-users.js
+++ b/src/server/services/api/api-users.js
@@ -4,7 +4,7 @@ import castArray from 'lodash/castArray';
 import isPlainObject from 'lodash/isPlainObject';
 import find from 'lodash/find';
 import some from 'lodash/some';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import settings from '../../config/settings';
 import logger from '../../lib/logger';
 import config from '../configstore';
@@ -45,7 +45,7 @@ const getSanitizedRecords = () => {
         const record = records[i];
 
         if (!record.id) {
-            record.id = uuid.v4();
+            record.id = uuid();
             shouldUpdate = true;
         }
 
@@ -195,7 +195,7 @@ export const create = (req, res) => {
         const hash = bcrypt.hashSync(password.trim(), salt);
         const records2 = getSanitizedRecords();
         const record = {
-            id: uuid.v4(),
+            id: uuid(),
             mtime: new Date().getTime(),
             enabled: enabled,
             name: name,

--- a/src/server/services/configstore/index.js
+++ b/src/server/services/configstore/index.js
@@ -1,6 +1,6 @@
 import events from 'events';
 import fs from 'fs';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import _ from 'lodash';
 import chalk from 'chalk';
 import parseJSON from 'parse-json';
@@ -54,7 +54,7 @@ const allMacros = [
     }
 ];
 const defaultMacros = allMacros.map((item) => {
-    item.id = uuid.v4();
+    item.id = uuid();
     item.mtime = new Date().getTime();
     item.repeat = 1;
     item.isDefault = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
         "allowJs": true,
         "sourceMap": true,
         "target": "es5",
-        "noUnusedLocals": true
+        "noUnusedLocals": true,
+        "esModuleInterop": true
     },
-    "include": ["./src/**/*"]
+    "include": [
+        "./src/**/*"
+    ]
 }


### PR DESCRIPTION
> Please upgrade to version 7 or higher. Older versions may use Math.random() in certain circumstances, which is known to be problematic. See https://v8.dev/blog/math-random for details.

[uuid@3.3.3](https://www.npmjs.com/package/uuid/v/3.3.3) has been deprecated, So I upgraded it and unified the calling method

note: The `sockjs`, `request` and `webpack-log` used by Luban now depend on the uuid `^3.3` version, This upgrade will not affect it

